### PR TITLE
Fix remapped shader not found

### DIFF
--- a/scripts/thunder_custom.shader
+++ b/scripts/thunder_custom.shader
@@ -213,7 +213,7 @@ textures/thunder_custom/foghull
 	fogparms ( .1 .025 .025 ) 4800
 }
 
-textures/thunder_custom/blend
+textures/thunder/blend
 {
 	qer_editorImage textures/shared_colors_src/black_d
 


### PR DESCRIPTION
Fixes #6 (Warn: R_RemapShader: new shader textures/thunder/blend not found). The visible consequence of this bug was that one of the lighting bolts is displayed at the beginning of the map.

![unvanquished_2025-08-23_001606_000](https://github.com/user-attachments/assets/062d703d-9413-43ec-a279-84587df38543)


Beyond that, the mistake didn't have further consequences because it was canceled out by an engine bug. When the replacement shader is not found, and it has already been searched previously, R_RemapShader uses a "defaulted" shader, which are never supposed to be used for rendering, as the replacement. The defaulted shader has 0 stages so it renders nothing, which happens to be what textures/thunder/blend is supposed to do.